### PR TITLE
chore: release on dependabot update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ on:
       - main
     paths:
       - "*.go"
+      - "go.mod"
+      - "go.sum"
 
 jobs:
   vet-and-test:


### PR DESCRIPTION
Make sure that merging dependabot PR triggers release flow.