### PR TITLE
fix: #7 JWK thumbprint includes optional members when calculated

### DIFF
--- a/examples/client/client.go
+++ b/examples/client/client.go
@@ -28,7 +28,7 @@ func main() {
 		panic(err)
 	}
 
-	// Create a DPoP proof token in order to request a bound token from the autorization server
+	// Create a DPoP proof token in order to request a bound token from the authorization server
 	claims := dpop.ProofTokenClaims{
 		RegisteredClaims: &jwt.RegisteredClaims{
 			Issuer:    "client",
@@ -46,7 +46,7 @@ func main() {
 		panic(err)
 	}
 
-	// Request a bound token from the autorization server
+	// Request a bound token from the authorization server
 	fmt.Println("Client - requesting a bound token from the authorization server")
 	body := tokenRequestBody{
 		Resource: "https://server.example.com/resource",

--- a/parse.go
+++ b/parse.go
@@ -267,27 +267,27 @@ func getThumbprintableJwkJSONbytes(jwk map[string]interface{}) ([]byte, error) {
 // Returns the string representation of a key in JSON format.
 func getKeyStringRepresentation(key interface{}) ([]byte, error) {
 	var keyParts interface{}
-	switch currentKey := key.(type) {
+	switch key := key.(type) {
 	case *ecdsa.PublicKey:
 		keyParts = map[string]interface{}{
 			"kty": "EC",
-			"crv": currentKey.Curve.Params().Name,
-			"x":   base64.RawURLEncoding.EncodeToString(currentKey.X.Bytes()),
-			"y":   base64.RawURLEncoding.EncodeToString(currentKey.Y.Bytes()),
+			"crv": key.Curve.Params().Name,
+			"x":   base64.RawURLEncoding.EncodeToString(key.X.Bytes()),
+			"y":   base64.RawURLEncoding.EncodeToString(key.Y.Bytes()),
 		}
 		break
 	case *rsa.PublicKey:
 		keyParts = map[string]interface{}{
 			"kty": "RSA",
-			"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(currentKey.E)).Bytes()),
-			"n":   base64.RawURLEncoding.EncodeToString(currentKey.N.Bytes()),
+			"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.E)).Bytes()),
+			"n":   base64.RawURLEncoding.EncodeToString(key.N.Bytes()),
 		}
 		break
 	case ed25519.PublicKey:
 		keyParts = map[string]interface{}{
 			"kty": "OKP",
 			"crv": "Ed25519",
-			"x":   base64.RawURLEncoding.EncodeToString(currentKey),
+			"x":   base64.RawURLEncoding.EncodeToString(key),
 		}
 		break
 	default:

--- a/parse.go
+++ b/parse.go
@@ -267,29 +267,27 @@ func getThumbprintableJwkJSONbytes(jwk map[string]interface{}) ([]byte, error) {
 // Returns the string representation of a key in JSON format.
 func getKeyStringRepresentation(key interface{}) ([]byte, error) {
 	var keyParts interface{}
-	switch key.(type) {
+	switch currentKey := key.(type) {
 	case *ecdsa.PublicKey:
-		ecdsaKey := key.(*ecdsa.PublicKey)
 		keyParts = map[string]interface{}{
 			"kty": "EC",
-			"crv": ecdsaKey.Curve.Params().Name,
-			"x":   base64.RawURLEncoding.EncodeToString(ecdsaKey.X.Bytes()),
-			"y":   base64.RawURLEncoding.EncodeToString(ecdsaKey.Y.Bytes()),
+			"crv": currentKey.Curve.Params().Name,
+			"x":   base64.RawURLEncoding.EncodeToString(currentKey.X.Bytes()),
+			"y":   base64.RawURLEncoding.EncodeToString(currentKey.Y.Bytes()),
 		}
 		break
 	case *rsa.PublicKey:
-		rsaKey := key.(*rsa.PublicKey)
 		keyParts = map[string]interface{}{
 			"kty": "RSA",
-			"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(rsaKey.E)).Bytes()),
-			"n":   base64.RawURLEncoding.EncodeToString(rsaKey.N.Bytes()),
+			"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(currentKey.E)).Bytes()),
+			"n":   base64.RawURLEncoding.EncodeToString(currentKey.N.Bytes()),
 		}
 		break
 	case ed25519.PublicKey:
 		keyParts = map[string]interface{}{
 			"kty": "OKP",
 			"crv": "Ed25519",
-			"x":   base64.RawURLEncoding.EncodeToString(key.(ed25519.PublicKey)),
+			"x":   base64.RawURLEncoding.EncodeToString(currentKey),
 		}
 		break
 	default:

--- a/parse.go
+++ b/parse.go
@@ -257,13 +257,14 @@ func getThumbprintableJwkJSONbytes(jwk map[string]interface{}) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	jwkHeaderJSONbytes, err := getKeyStringRepresentation(minimalJwk)
+	jwkHeaderJSONBytes, err := getKeyStringRepresentation(minimalJwk)
 	if err != nil {
 		return nil, err
 	}
-	return jwkHeaderJSONbytes, nil
+	return jwkHeaderJSONBytes, nil
 }
 
+// Returns the string representation of a key in JSON format.
 func getKeyStringRepresentation(key interface{}) ([]byte, error) {
 	var keyParts interface{}
 	switch key.(type) {

--- a/proof_test.go
+++ b/proof_test.go
@@ -19,7 +19,7 @@ const (
 // Test that a valid proof and valid bound token are accepted without error
 func TestValidate_WithValidProofAndBoundAccessToken(t *testing.T) {
 	// Arrange
-	// Create a access token hash
+	// Create an access token hash
 	accessToken := "someToken"
 	h := sha256.New()
 	_, err := h.Write([]byte(accessToken))


### PR DESCRIPTION
### Describe your changes

Extracted functionality to parse a JWK to a function. Use that to extract a "minimal" JWK (the JWK without optional or custom fields) to do the JWK fingerprinting with 

### Issue ticket number and link

- Fixes #7 

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
