### PR TITLE
docs: clarify wording on `ParseOptions`

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -41,11 +41,11 @@ type ParseOptions struct {
 	// The expected nonce if the authorization server has issued a nonce.
 	Nonce string
 
-	// Used to control if the `iat` field is used to control the proof age.
+	// Used to control if the `iat` field is within allowed clock-skew.
 	// If set to true the authorization server has to validate the nonce timestamp itself.
 	NonceHasTimestamp bool
 
-	// The allowed age of the proof. Defaults to 1 minute if not specified.
+	// The allowed clock-skew on the `iat` of the proof. Defaults to 1 minute if not specified.
 	TimeWindow *time.Duration
 
 	// dpop_jkt parameter that is optionally sent by the client to the authorization server on token request.


### PR DESCRIPTION
### Describe your changes

Clarify that `TimeStamp` and `NonceHasTimestamp` is used for checking clock-skew only.

### Issue ticket number and link

- Fixes #13 

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
